### PR TITLE
Adds CADC download option, plus fixes bugs.

### DIFF
--- a/nifty/pipeline/downloadFromGeminiPublicArchive/ndmapperDownloader.py
+++ b/nifty/pipeline/downloadFromGeminiPublicArchive/ndmapperDownloader.py
@@ -31,6 +31,7 @@ POSSIBILITY OF SUCH DAMAGE."""
 
 import os, os.path
 import sys
+import logging
 from contextlib import closing
 from StringIO import StringIO
 import urllib2
@@ -38,7 +39,7 @@ import xml.dom.minidom as xmd
 import tarfile
 import hashlib
 
-def download_query_gemini(query, dirname='', cookieName=''):
+def download_query_gemini(program, dirname='', cookieName=''):
     """
     Perform a user-specified Gemini science archive query and save the files
     returned to a specified directory.
@@ -54,16 +55,25 @@ def download_query_gemini(query, dirname='', cookieName=''):
     which should be optimal as long as the archive isn't unreasonably large
     (to do: consider adding an option to write it to a temporary file).
 
+    # Modified 2020 by Nat Comeau
+
     Parameters
     ----------
 
-    query : str
-        The query URL (or just the path component) to request from the server.
+    program : str 
+        The Gemini program ID to request from the server.
 
     dirname : str, optional
         The (absolute or relative) directory path in which to place the files.
 
     """
+
+    # Modified 2020 by Nat Comeau
+    query = 'https://archive.gemini.edu/download/'+ str(program) + '/notengineering/NotFail/present/canonical'
+    logging.info('\nDownloading data from Gemini public archive to ./rawData. This will take a few minutes.')
+    logging.info('\nURL used for the download: \n' + str(query))
+
+
     checksum_fn = 'md5sums.txt'
     aux_fn = [checksum_fn, 'README.txt']
 

--- a/nifty/pipeline/nifsPipeline.py
+++ b/nifty/pipeline/nifsPipeline.py
@@ -77,7 +77,7 @@ from nifsUtils import datefmt, printDirectoryLists, writeList, getParam, interac
 
 # The current version:
 # TODO(nat): fix this to import the version from setup.py.
-__version__ = "1.0.0"
+__version__ = "2.0.0"
 
 # The time when Nifty was started is:
 startTime = str(datetime.now())
@@ -101,7 +101,6 @@ def start(args):
     """
     # Save starting path for later use and change one directory up.
     path = os.getcwd()
-    print "IT WORKED!"
     # Get paths to built-in Nifty data. Special code in setup.py makes sure recipes/ and
     # runtimeData/ will be installed when someone installs Nifty, and accessible in this way.
     RECIPES_PATH = pkg_resources.resource_filename('nifty', 'recipes/')
@@ -127,9 +126,7 @@ def start(args):
     logging.info("#             NIFTY                #")
     logging.info("#   NIFS Data Reduction Pipeline   #")
     logging.info("#         Version "+ __version__+ "            #")
-    logging.info("#         July 25th, 2017          #")
-    logging.info("#     Marie Lemoine-Busserolle     #")
-    logging.info("# Gemini Observatory, Hilo, Hawaii #")
+    logging.info("#              2020                #")
     logging.info("#                                  #")
     logging.info("####################################\n")
 

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1207,8 +1207,8 @@ def downloadQueryCadc(program, directory='./rawData'):
     for url, pid in zip(urls, pids):
         try:
             filename = getFile(url)
-            shutil.move(filename, directory+'/'+filename)
-            logging.debug("Downloaded {}".format(filename))
+            shutil.move(filename, os.path.join(directory, filename.lstrip('.temp-')))
+            logging.debug("Downloaded {}".format(filename.lstrip('.temp-')))
         except Exception as e:
             logging.error("A frame failed to download.")
             raise e
@@ -1221,12 +1221,12 @@ def getFile(url):
     r = requests.get(url, stream=True)
     # Parse out filename from header
     try:
-        filename = re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
+        filename = '.temp-' + re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
     except KeyError:
         # 'Content-Disposition' header wasn't found, so parse filename from URL
         # Typical URL looks like:
         # https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEM/N20140505S0114.fits?RUNID=mf731ukqsipqpdgk
-        filename = (url.split('/')[-1]).split('?')[0]
+        filename = '.temp-' + (url.split('/')[-1]).split('?')[0]
     # Write the fits file
     with open(filename, 'wb') as f:
         for chunk in r.iter_content(chunk_size=128):

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1206,7 +1206,6 @@ def downloadQueryCadc(program, directory='./rawData'):
     urls = cadc.get_data_urls(result)
     for url, pid in zip(urls, pids):
         try:
-            filename = getFile(url)
             shutil.move(filename, directory+'/'+filename)
             logging.debug("Downloaded {}".format(filename))
         except Exception as e:

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1206,24 +1206,27 @@ def download_query_cadc(program, directory='./rawData'):
     urls = cadc.get_data_urls(result)
     for url, pid in zip(urls, pids):
         try:
-            r = requests.get(url, stream=True)
-            # Parse out filename from header
-            filename = re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
-            # Check that filename makes sense (ie starts with N and ends with .fits)
-            pattern = re.compile(r"N.*\.fits")
-            if not pattern.match(filename):
-                raise ValueError("Bad download filename.")
-            # Write the fits file
-            with open(directory+'/'+filename, 'wb') as f:
-                for chunk in r.iter_content(chunk_size=128):
-                    f.write(chunk)
-            logging.debug("Downloaded {}".format(directory+'/'+pid+'.fits'))
+            filename = get_file(url)
+            shutil.move(filename, directory+'/'+filename)
+            logging.debug("Downloaded {}".format(filename))
         except Exception as e:
             logging.error("A frame failed to download.")
             raise e
 
 
+def get_file(url):
+    """
+    Gets a file from the specified url and returns the filename.
+    """
+    r = requests.get(url, stream=True)
+    # Parse out filename from header
+    filename = re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
+    # Write the fits file
+    with open(filename, 'wb') as f:
+        for chunk in r.iter_content(chunk_size=128):
+            f.write(chunk)
 
+    return filename
 
 
 

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1206,6 +1206,7 @@ def downloadQueryCadc(program, directory='./rawData'):
     urls = cadc.get_data_urls(result)
     for url, pid in zip(urls, pids):
         try:
+            filename = getFile(url)
             shutil.move(filename, directory+'/'+filename)
             logging.debug("Downloaded {}".format(filename))
         except Exception as e:

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -211,9 +211,9 @@ def interactiveNIFSInput():
         "You can provide a cookie from your Gemini public archive login session to automatically " + \
         "download proprietary data."
         )
-        cadc = getParam(
-        "Download from CADC? If no download will be from Gemini. [no]: ",
-        'no',
+        dataSource = getParam(
+        "Select a raw data source; 'GSA' for Gemini Science Archive, 'CADC' for Canadian Astronomy Data Centre. [GSA]: ",
+        'GSA',
         "Automatic downloads can happen from either the Gemini Science Archive or the Canadian Astronomy Data Centre."
         )
         skyThreshold = getParam(
@@ -419,7 +419,7 @@ def interactiveNIFSInput():
         config['sortConfig']['rawPath'] = rawPath
         config['sortConfig']['program'] = program
         config['sortConfig']['proprietaryCookie'] = proprietaryCookie
-        config['sortConfig']['cadc'] = cadc
+        config['sortConfig']['dataSource'] = dataSource
         config['sortConfig']['skyThreshold'] = skyThreshold
         config['sortConfig']['sortTellurics'] = sortTellurics
         config['sortConfig']['telluricTimeThreshold'] = telluricTimeThreshold
@@ -1206,7 +1206,7 @@ def downloadQueryCadc(program, directory='./rawData'):
     urls = cadc.get_data_urls(result)
     for url, pid in zip(urls, pids):
         try:
-            filename = get_file(url)
+            filename = getFile(url)
             shutil.move(filename, directory+'/'+filename)
             logging.debug("Downloaded {}".format(filename))
         except Exception as e:

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1186,7 +1186,7 @@ def MEFarith(MEF, image, op, result):
 
 #-----------------------------------------------------------------------------#
 
-def download_query_cadc(program, directory='./rawData'):
+def downloadQueryCadc(program, directory='./rawData'):
     """
     Finds and downloads all CADC files for a particular gemini program ID to
     the current working directory.
@@ -1214,7 +1214,7 @@ def download_query_cadc(program, directory='./rawData'):
             raise e
 
 
-def get_file(url):
+def getFile(url):
     """
     Gets a file from the specified url and returns the filename.
     """

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1231,17 +1231,17 @@ def getFile(url):
         # Typical URL looks like:
         # https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEM/N20140505S0114.fits?RUNID=mf731ukqsipqpdgk
         filename = '.temp-' + (url.split('/')[-1]).split('?')[0]
-    # Write the fits file
-    with open(filename, 'wb') as f:
-        for chunk in r.iter_content(chunk_size=128):
-            f.write(chunk)
-
-    # Do MD5 Verification of the file; raise IO error if a problem happened.
+    
+    # Write the fits file, verifying the md5 hash as we go
     try:
         server_checksum = r.headers['Content-MD5']
-        with open(filename, 'rb') as f:
-            download_checksum = hashlib.md5(f.read()).hexdigest()
-        if server_checksum != download_checksum:
+        download_checksum = hashlib.md5()
+        with open(filename, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=128):
+                f.write(chunk)
+                download_checksum.update(chunk)
+        
+        if server_checksum != download_checksum.hexdigest():
             logging.error("Problem downloading {} from {}.".format(filename, url))
             raise IOError
 

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1220,7 +1220,13 @@ def getFile(url):
     """
     r = requests.get(url, stream=True)
     # Parse out filename from header
-    filename = re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
+    try:
+        filename = re.findall("filename=(.+)", r.headers['Content-Disposition'])[0]
+    except KeyError:
+        # 'Content-Disposition' header wasn't found, so parse filename from URL
+        # Typical URL looks like:
+        # https://www.cadc-ccda.hia-iha.nrc-cnrc.gc.ca/data/pub/GEM/N20140505S0114.fits?RUNID=mf731ukqsipqpdgk
+        filename = (url.split('/')[-1]).split('?')[0]
     # Write the fits file
     with open(filename, 'wb') as f:
         for chunk in r.iter_content(chunk_size=128):

--- a/nifty/pipeline/nifsUtils.py
+++ b/nifty/pipeline/nifsUtils.py
@@ -1204,14 +1204,18 @@ def downloadQueryCadc(program, directory='./rawData'):
     pids = list(result['productID'])
 
     urls = cadc.get_data_urls(result)
+    cwd = os.getcwd()
+    os.chdir(directory)
     for url, pid in zip(urls, pids):
         try:
             filename = getFile(url)
-            shutil.move(filename, os.path.join(directory, filename.lstrip('.temp-')))
+            shutil.move(filename, filename.lstrip('.temp-'))
             logging.debug("Downloaded {}".format(filename.lstrip('.temp-')))
         except Exception as e:
             logging.error("A frame failed to download.")
+            os.chdir(cwd)
             raise e
+    os.chdir(cwd)
 
 
 def getFile(url):

--- a/nifty/pipeline/objectoriented/GetConfig.py
+++ b/nifty/pipeline/objectoriented/GetConfig.py
@@ -73,7 +73,7 @@ class GetConfig(object):
         """
         if os.path.exists(configFile):
             os.remove(configFile)
-            shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
+        shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
 
 
     def makeConfig(self):

--- a/nifty/pipeline/objectoriented/GetConfig.py
+++ b/nifty/pipeline/objectoriented/GetConfig.py
@@ -72,6 +72,8 @@ class GetConfig(object):
         self.parser.add_argument('-i', '--interactive', dest = 'interactive', default = False, action = 'store_true', help = 'Create a config.cfg file interactively.')
         # Ability to repeat the last data reduction
         self.parser.add_argument('-r', '--repeat', dest = 'repeat', default = False, action = 'store_true', help = 'Repeat the last data reduction, loading saved reduction parameters from runtimeData/config.cfg.')
+        # Specify where downloads come from; either Gemini or CADC.
+        self.parser.add_argument('-c', '--cadc', dest = 'cadc', default = False, action = 'store_true', help = 'Download raw data from Canadian Astronomy Data Centre rather than the Gemini Science Archive.')
         # Ability to load a built-in configuration file (recipe)
         self.parser.add_argument('-l', '--recipe', dest = 'recipe', action = 'store', help = 'Load data reduction parameters from the a provided recipe. Default is default_input.cfg.')
         # Ability to load your own configuration file
@@ -85,6 +87,7 @@ class GetConfig(object):
         self.repeat = self.args.repeat
         self.fullReduction = self.args.fullReduction
         self.inputfile = self.args.inputfile
+        self.cadc = self.args.cadc
 
         if self.inputfile:
             # Load input from a .cfg file user specified at command line.
@@ -121,3 +124,14 @@ class GetConfig(object):
             with open('./' + self.configFile, 'w') as self.outfile:
                 self.config.write(self.outfile)
             logging.info("\nData reduction parameters for this reduction were copied from recipes/defaultConfig.cfg to ./config.cfg.")
+
+        if self.cadc:
+            try:
+                with open('./' + self.configFile, 'r') as self.config_file:
+                    self.config = ConfigObj(self.config_file, unrepr=True)
+                    self.config['sortConfig']['cadc'] = self.cadc
+                with open('./' + self.configFile, 'w') as self.outfile:
+                    self.config.write(self.outfile)
+                logging.debug("Set CADC flag in config file.")
+            except:
+                raise ValueError("Failed to set CADC download option.")

--- a/nifty/pipeline/objectoriented/GetConfig.py
+++ b/nifty/pipeline/objectoriented/GetConfig.py
@@ -89,7 +89,7 @@ class GetConfig(object):
         # Ability to repeat the last data reduction
         self.parser.add_argument('-r', '--repeat', dest = 'repeat', default = False, action = 'store_true', help = 'Repeat the last data reduction, loading saved reduction parameters from runtimeData/config.cfg.')
         # Specify where downloads come from; either Gemini or CADC.
-        self.parser.add_argument('-d', '--data-source', dest = 'dataSource', default = 'GSA', action = 'store', help = 'Download raw data from the Canadian Astronomy Data Centre or the Gemini Science Archive. Valid options are "GSA" or "CADC".')
+        self.parser.add_argument('-s', '--data-source', dest = 'dataSource', default = 'GSA', action = 'store', help = 'Download raw data from the Canadian Astronomy Data Centre or the Gemini Science Archive. Valid options are "GSA" or "CADC".')
         # Ability to load a built-in configuration file (recipe)
         self.parser.add_argument('-l', '--recipe', dest = 'recipe', action = 'store', help = 'Load data reduction parameters from the a provided recipe. Default is default_input.cfg.')
         # Ability to load your own configuration file

--- a/nifty/pipeline/objectoriented/GetConfig.py
+++ b/nifty/pipeline/objectoriented/GetConfig.py
@@ -64,9 +64,17 @@ class GetConfig(object):
         """
         Checks that a config file exists and if not, sets Nifty to use default configuration.
         """
+        if not os.path.exists(configFile):
+            shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
+
+    def overwriteWithDefault(self, configFile):
+        """
+        Overwrites with default configuration.
+        """
         if os.path.exists(configFile):
             os.remove(configFile)
             shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
+
 
     def makeConfig(self):
         """
@@ -113,7 +121,7 @@ class GetConfig(object):
             self.fullReduction = interactiveNIFSInput()
 
         if self.fullReduction:
-            self.checkConfigExists(self.configFile)
+            self.overwriteWithDefault(self.configFile)
             # Update default config file with path to raw data or program ID.
             with open('./' + self.configFile, 'r') as self.config_file:
                 self.config = ConfigObj(self.config_file, unrepr=True)
@@ -136,9 +144,9 @@ class GetConfig(object):
                 self.checkConfigExists(self.configFile)
                 with open('./' + self.configFile, 'r') as self.config_file:
                     self.config = ConfigObj(self.config_file, unrepr=True)
-                    self.config['sortConfig']['cadc'] = self.cadc
+                    self.config['sortConfig']['dataSource'] = self.dataSource
                 with open('./' + self.configFile, 'w') as self.outfile:
                     self.config.write(self.outfile)
-                logging.debug("Set CADC flag in config file.")
+                logging.debug("Set dataSource option in config file.")
             except:
-                raise ValueError("Failed to set CADC download option.")
+                raise ValueError("Failed to set dataSource option.")

--- a/nifty/pipeline/objectoriented/GetConfig.py
+++ b/nifty/pipeline/objectoriented/GetConfig.py
@@ -65,7 +65,7 @@ class GetConfig(object):
         Checks that a config file exists and if not, sets Nifty to use default configuration.
         """
         if not os.path.exists(configFile):
-            shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
+            shutil.copy(os.path.join(self.RECIPES_PATH,'defaultConfig.cfg'), configFile)
 
     def overwriteWithDefault(self, configFile):
         """
@@ -73,7 +73,7 @@ class GetConfig(object):
         """
         if os.path.exists(configFile):
             os.remove(configFile)
-        shutil.copy(self.RECIPES_PATH+'defaultConfig.cfg', configFile)
+        shutil.copy(os.path.join(self.RECIPES_PATH,'defaultConfig.cfg'), configFile)
 
 
     def makeConfig(self):
@@ -107,9 +107,9 @@ class GetConfig(object):
 
         if self.inputfile:
             # Load input from a .cfg file user specified at command line.
-            if self.inputfile != self.configFile and os.path.exists('./'+ self.configFile):
-                os.remove('./'+ self.configFile)
-                shutil.copy(self.inputfile, './'+ self.configFile)
+            if self.inputfile != self.configFile and os.path.exists(self.configFile):
+                os.remove(self.configFile)
+                shutil.copy(self.inputfile, self.configFile)
             logging.info("\nPipeline configuration for this data reduction was read from " + str(self.inputfile) + \
             ", and if not named config.cfg, copied to ./config.cfg.")
 
@@ -123,7 +123,7 @@ class GetConfig(object):
         if self.fullReduction:
             self.overwriteWithDefault(self.configFile)
             # Update default config file with path to raw data or program ID.
-            with open('./' + self.configFile, 'r') as self.config_file:
+            with open(self.configFile, 'r') as self.config_file:
                 self.config = ConfigObj(self.config_file, unrepr=True)
                 self.sortConfig = self.config['sortConfig']
                 if self.fullReduction[0] == "G":
@@ -134,7 +134,7 @@ class GetConfig(object):
                     # Else treat it as a path.
                     self.sortConfig['program'] = ""
                     self.sortConfig['rawPath'] = self.fullReduction
-            with open('./' + self.configFile, 'w') as self.outfile:
+            with open(self.configFile, 'w') as self.outfile:
                 self.config.write(self.outfile)
             logging.info("\nData reduction parameters for this reduction were copied from recipes/defaultConfig.cfg to ./config.cfg.")
 
@@ -142,10 +142,10 @@ class GetConfig(object):
         if self.dataSource != 'GSA':
             try:
                 self.checkConfigExists(self.configFile)
-                with open('./' + self.configFile, 'r') as self.config_file:
+                with open(self.configFile, 'r') as self.config_file:
                     self.config = ConfigObj(self.config_file, unrepr=True)
                     self.config['sortConfig']['dataSource'] = self.dataSource
-                with open('./' + self.configFile, 'w') as self.outfile:
+                with open(self.configFile, 'w') as self.outfile:
                     self.config.write(self.outfile)
                 logging.debug("Set dataSource option in config file.")
             except:

--- a/nifty/pipeline/steps/nifsSort.py
+++ b/nifty/pipeline/steps/nifsSort.py
@@ -148,13 +148,10 @@ def start():
             logging.info('\nDownloading data from the CADC archive to ./rawData. This will take a few minutes.')
             downloadQueryCadc(program, os.getcwd()+'/rawData')
         elif dataSource == 'GSA':
-            url = 'https://archive.gemini.edu/download/'+ str(program) + '/notengineering/NotFail/present/canonical'
-            logging.info('\nDownloading data from Gemini public archive to ./rawData. This will take a few minutes.')
-            logging.info('\nURL used for the download: \n' + str(url))
             if proprietaryCookie:
-                download_query_gemini(url, './rawData', proprietaryCookie)
+                download_query_gemini(program, './rawData', proprietaryCookie)
             else:
-                download_query_gemini(url, './rawData')
+                download_query_gemini(program, './rawData')
         else:
             raise ValueError("Invalid dataSource in config file.")
         

--- a/nifty/pipeline/steps/nifsSort.py
+++ b/nifty/pipeline/steps/nifsSort.py
@@ -44,7 +44,7 @@ from ..configobj.configobj import ConfigObj
 # TODO(nat): goodness, this is a lot of functions. It would be nice to split this up somehow.
 from ..nifsUtils import getUrlFiles, getFitsHeader, FitsKeyEntry, stripString, stripNumber, \
 datefmt, checkOverCopy, checkQAPIreq, checkDate, writeList, checkEntry, timeCalc, checkSameLengthFlatLists, \
-rewriteSciImageList, datefmt, download_query_cadc
+rewriteSciImageList, datefmt, downloadQueryCadc
 
 # Import NDMapper gemini data download, by James E.H. Turner.
 from ..downloadFromGeminiPublicArchive import download_query_gemini
@@ -127,7 +127,7 @@ def start():
         sortConfig = options['sortConfig']
         rawPath = sortConfig['rawPath']
         program = sortConfig['program']
-        cadc = sortConfig['cadc']
+        dataSource = sortConfig['dataSource']
         proprietaryCookie = sortConfig['proprietaryCookie']
         skyThreshold = sortConfig['skyThreshold']
         sortTellurics = sortConfig['sortTellurics']
@@ -144,10 +144,10 @@ def start():
     if program:
         if not os.path.exists('./rawData'):
             os.mkdir('./rawData')
-        if cadc:
+        if dataSource == 'CADC':
             logging.info('\nDownloading data from the CADC archive to ./rawData. This will take a few minutes.')
-            download_query_cadc(program, os.getcwd()+'/rawData')
-        else:
+            downloadQueryCadc(program, os.getcwd()+'/rawData')
+        elif dataSource == 'GSA':
             url = 'https://archive.gemini.edu/download/'+ str(program) + '/notengineering/NotFail/present/canonical'
             logging.info('\nDownloading data from Gemini public archive to ./rawData. This will take a few minutes.')
             logging.info('\nURL used for the download: \n' + str(url))
@@ -155,6 +155,8 @@ def start():
                 download_query_gemini(url, './rawData', proprietaryCookie)
             else:
                 download_query_gemini(url, './rawData')
+        else:
+            raise ValueError("Invalid dataSource in config file.")
         
         rawPath = os.getcwd()+'/rawData'
 

--- a/nifty/pipeline/steps/nifsSort.py
+++ b/nifty/pipeline/steps/nifsSort.py
@@ -44,7 +44,7 @@ from ..configobj.configobj import ConfigObj
 # TODO(nat): goodness, this is a lot of functions. It would be nice to split this up somehow.
 from ..nifsUtils import getUrlFiles, getFitsHeader, FitsKeyEntry, stripString, stripNumber, \
 datefmt, checkOverCopy, checkQAPIreq, checkDate, writeList, checkEntry, timeCalc, checkSameLengthFlatLists, \
-rewriteSciImageList, datefmt
+rewriteSciImageList, datefmt, download_query_cadc
 
 # Import NDMapper gemini data download, by James E.H. Turner.
 from ..downloadFromGeminiPublicArchive import download_query_gemini
@@ -127,6 +127,7 @@ def start():
         sortConfig = options['sortConfig']
         rawPath = sortConfig['rawPath']
         program = sortConfig['program']
+        cadc = sortConfig['cadc']
         proprietaryCookie = sortConfig['proprietaryCookie']
         skyThreshold = sortConfig['skyThreshold']
         sortTellurics = sortConfig['sortTellurics']
@@ -141,17 +142,21 @@ def start():
 
     # Download data from gemini public archive to ./rawData/.
     if program:
-        url = 'https://archive.gemini.edu/download/'+ str(program) + '/notengineering/NotFail/present/canonical'
         if not os.path.exists('./rawData'):
             os.mkdir('./rawData')
-        logging.info('\nDownloading data from Gemini public archive to ./rawData. This will take a few minutes.')
-        logging.info('\nURL used for the download: \n' + str(url))
-        if proprietaryCookie:
-            download_query_gemini(url, './rawData', proprietaryCookie)
+        if cadc:
+            logging.info('\nDownloading data from the CADC archive to ./rawData. This will take a few minutes.')
+            download_query_cadc(program, os.getcwd()+'/rawData')
         else:
-            download_query_gemini(url, './rawData')
+            url = 'https://archive.gemini.edu/download/'+ str(program) + '/notengineering/NotFail/present/canonical'
+            logging.info('\nDownloading data from Gemini public archive to ./rawData. This will take a few minutes.')
+            logging.info('\nURL used for the download: \n' + str(url))
+            if proprietaryCookie:
+                download_query_gemini(url, './rawData', proprietaryCookie)
+            else:
+                download_query_gemini(url, './rawData')
+        
         rawPath = os.getcwd()+'/rawData'
-
 
     ############################################################################
     ############################################################################

--- a/nifty/pipeline/steps/nifsSort.py
+++ b/nifty/pipeline/steps/nifsSort.py
@@ -127,7 +127,11 @@ def start():
         sortConfig = options['sortConfig']
         rawPath = sortConfig['rawPath']
         program = sortConfig['program']
-        dataSource = sortConfig['dataSource']
+        # Backwards compatability with old config files
+        try:
+            dataSource = sortConfig['dataSource']
+        except KeyError:
+            dataSource = 'GSA'
         proprietaryCookie = sortConfig['proprietaryCookie']
         skyThreshold = sortConfig['skyThreshold']
         sortTellurics = sortConfig['sortTellurics']

--- a/nifty/recipes/defaultConfig.cfg
+++ b/nifty/recipes/defaultConfig.cfg
@@ -28,6 +28,7 @@ mergeMethod = ''
 [sortConfig]
 rawPath = ''
 program = ''
+cadc=False
 proprietaryCookie = ''
 skyThreshold = 2.0
 sortTellurics = True

--- a/nifty/recipes/defaultConfig.cfg
+++ b/nifty/recipes/defaultConfig.cfg
@@ -28,7 +28,7 @@ mergeMethod = ''
 [sortConfig]
 rawPath = ''
 program = ''
-cadc=False
+dataSource='GSA'
 proprietaryCookie = ''
 skyThreshold = 2.0
 sortTellurics = True

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Scientific/Engineering :: Physics',
     ],
     keywords='Gemini NIFS nifs pipeline reduction data IRAF iraf PYRAF pyraf astronomy integral field spectroscopy ifs ifu',
-    python_requires='~=2.7',
+    python_requires='<=2.7.17',
     scripts=SCRIPTS, # TODO(nat): Update this to use entry_points instead of scripts for better cross-platform performance
     packages=find_packages(),
     package_data=PACKAGE_DATA

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ PACKAGE_DATA = {
 
 setup(
     name=NAME,
-    version="1.0.1",
-    author='mbusserolle',
-    author_email='mbussero@gemini.edu',
+    version="2.0.0",
+    author='ncomeau',
+    author_email='ncomeau@uvic.ca',
     description='Gemini Instruments Data Reduction Framework.',
     long_description = README_TEXT,
-    url='http://www.gemini.edu',
+    url='https://github.com/Nat1405/Nifty4Gemini',
     license='MIT',
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Users can now specify -c (eg; runNifty nifsPipeline -c ...)
to download raw data from the Canadian Astronomy Data Centre.
This has been tested to work from the interactive config session
(runNifty nifsPipeline -i) and the fully automatic mode
(runNifty nifsPipeline -c -f <PROGRAM ID>).